### PR TITLE
fixing bug of implementing sorting in CAR X FOCUS

### DIFF
--- a/services/view.service.js
+++ b/services/view.service.js
@@ -407,6 +407,7 @@ module.exports = FileReport = {
               'sum_alias'            AS sum_alias,
               (CASE
                   WHEN (SUBSTRING(UPPER(TRIM(view.name)), 'CAR VALIDADO') IS NOT NULL) THEN 'area'
+                  WHEN (SUBSTRING(UPPER(TRIM(view.name)), 'CAR X FOCOS') IS NOT NULL) THEN 'count_alias'
                   ELSE 'sum_alias'
               END)                   AS sort_field,
               (CASE

--- a/utils/filter/filter.utils.js
+++ b/utils/filter/filter.utils.js
@@ -353,8 +353,7 @@ const filterUtils = {
         await setFilter[filtered](conn, sql, filter, columns, cod, table, view);
       }
     }
-
-    sql.order = (params.sum && params.sortColumn && params.sortOrder) ? ` ORDER BY ${params.sortColumn} ${params.sortOrder == '1'?'ASC':'DESC'} ` : ``;
+    sql.order = (params.sortColumn && params.sortOrder) ? ` ORDER BY ${params.sortColumn} ${params.sortOrder == '1'?'ASC':'DESC'} ` : ``;
     sql.limit = (params.limit) ? ` LIMIT ${params.limit} ` : ``;
     sql.offset = (params.offset) ? ` OFFSET ${params.offset} ` : ``;
 


### PR DESCRIPTION
fixing ordination bug in CAR X FOCUS

Removing the "params.sum &&" in the sql_order variable in the file: "utils / filter / filter.utils.js"
Create a case that replaces the value of "sort_field" from "sum_alias" to "count_alias" in the file: "services / view.service.js"