### PR TITLE
New Endpoint - updateDatastore

### DIFF
--- a/controllers/geoserver.js
+++ b/controllers/geoserver.js
@@ -25,3 +25,8 @@ exports.saveGroupLayer = async (req, res, next) => {
   const jsonConf = req.body;
   res.json(await GeoServerService.saveGroupLayer(jsonConf));
 };
+
+exports.updateDataStore = async (req, res, _next) => {
+  const jsonData = req.body;
+  res.json(await GeoServerService.updateDataStore(jsonData));
+}

--- a/routes/geoserver.js
+++ b/routes/geoserver.js
@@ -8,5 +8,6 @@ router.get('/updateViewsFilter', geoserverController.updateViews);
 router.delete('/deleteViews', geoserverController.deleteViews);
 router.post('/saveViews', geoserverController.saveViews);
 router.post('/saveGroupLayer', geoserverController.saveGroupLayer);
+router.put('/updateDataStore', geoserverController.updateDataStore )
 
 module.exports = router

--- a/services/geoServer.service.js
+++ b/services/geoServer.service.js
@@ -254,7 +254,7 @@ module.exports = geoServerService = {
         "title": title,
         "description": description,
         "abstract": abstract,
-        "srs": "EPSG:${confGeoServer.sridTerraMa}",
+        "srs": `EPSG:${confGeoServer.sridTerraMa}`,
         "projectionPolicy": "FORCE_DECLARED",
         "enabled": true,
         "store": {

--- a/services/geoServer.service.js
+++ b/services/geoServer.service.js
@@ -151,16 +151,22 @@ module.exports = geoServerService = {
     }
   },
 
-  async validateDataStore(nameWorkspace, nameDataStrore) {
-    if (nameDataStrore) {
+  async validateDataStore(nameWorkspace, nameDataStore) {
+    if (nameDataStore) {
       const urlD = `${confGeoServer.host}workspaces/${nameWorkspace}/datastores`;
-      const method = await this.setMethod(`${urlD}/${nameDataStrore}.json`);
+      const method = await this.setMethod(`${urlD}/${nameDataStore}.json`);
 
       if (method === 'post') {
-        const data = geoServerUtil.setDataStore(confDb, nameWorkspace, nameDataStrore);
+        const data = geoServerUtil.setDataStore(confDb, nameWorkspace, nameDataStore);
         console.log(await this.saveGeoServer(data.dataStore.name, method, urlD, data, CONFIG_JSON));
       }
     }
+  },
+
+  async updateDataStore({nameWorkspace, nameDataStore}) {
+    const urlD = `${confGeoServer.host}workspaces/${nameWorkspace}/datastores`;
+    const data = geoServerUtil.setDataStore(confDb, nameWorkspace, nameDataStore);
+    console.log(await this.saveGeoServer(data.dataStore.name, 'put', urlD, data, CONFIG_JSON))
   },
 
   async deleteView(views){

--- a/utils/geoServer.utils.js
+++ b/utils/geoServer.utils.js
@@ -20,7 +20,7 @@ setViewJson = function(json, view){
         "nativeName": view.name,
         "title": view.title,
         "keywords": { "string": [ "features", view.title ] },
-        "srs": "EPSG:${confGeoServer.sridTerraMa}",
+        "srs": `EPSG:${confGeoServer.sridTerraMa}`,
         "nativeBoundingBox": { },
         "latLonBoundingBox": { },
         "projectionPolicy": "FORCE_DECLARED",

--- a/utils/geoServer.utils.js
+++ b/utils/geoServer.utils.js
@@ -96,14 +96,14 @@ updateBoundingBox = function(json){
       "maxx": 180,
       "miny": -90,
       "maxy": 90,
-      "crs": "EPSG:${confGeoServer.sridTerraMa}"
+      "crs": `EPSG:${confGeoServer.sridTerraMa}`
   };
   json.featureType.latLonBoundingBox = {
       "minx": -180,
       "maxx": 180,
       "miny": -90,
       "maxy": 90,
-      "crs": "EPSG:${confGeoServer.sridTerraMa}"
+      "crs": `EPSG:${confGeoServer.sridTerraMa}`
   };
 };
 
@@ -123,7 +123,7 @@ const geoServerUtil = {
         "enabled": true,
         "workspace": {
           "name": nameWorkspace,
-          "href": `http://www.terrama2.dpi.inpe.br/mpmt/geoserver/rest/workspaces/${nameWorkspace}.json`
+          "href": `${confGeoServer.host}workspaces/${nameWorkspace}.json`
         },
         "connectionParameters": {
           "entry": [


### PR DESCRIPTION
Fixing some strings to template literals OLD: "EPSG:${confGeoServer.sridTerraMa}" > NEW "EPSG:${confGeoServer.sridTerraMa}"

Creating a new endpoint to update a data-store given a workspace name (`nameWorkspace`) and a data-store name (`nameDatastore`);

It will get the config specs and apply to the data store.