### PR TITLE
Add two new endpoints and fix some typos

### DIFF
--- a/controllers/geoserver.js
+++ b/controllers/geoserver.js
@@ -29,4 +29,9 @@ exports.saveGroupLayer = async (req, res, next) => {
 exports.updateDataStore = async (req, res, _next) => {
   const jsonData = req.body;
   res.json(await GeoServerService.updateDataStore(jsonData));
-}
+};
+
+exports.updateAllDataStores = async (_req, res, _next) => {
+  const result = await GeoServerService.updateAllDataStores()
+  res.status(200).json(result);
+};

--- a/geoserver-conf/views/mosaic/mosaicFeatureType.json
+++ b/geoserver-conf/views/mosaic/mosaicFeatureType.json
@@ -4,7 +4,7 @@
     "nativeName":"carView",
     "title": "carView",
     "keywords": { "string": [ "features",  "carView" ] },
-    "srs": "EPSG:${confGeoServer.sridTerraMa}",
+    "srs": 4674,
     "projectionPolicy": "FORCE_DECLARED",
     "enabled": true,
     "metadata": {

--- a/routes/geoserver.js
+++ b/routes/geoserver.js
@@ -8,6 +8,8 @@ router.get('/updateViewsFilter', geoserverController.updateViews);
 router.delete('/deleteViews', geoserverController.deleteViews);
 router.post('/saveViews', geoserverController.saveViews);
 router.post('/saveGroupLayer', geoserverController.saveGroupLayer);
-router.put('/updateDataStore', geoserverController.updateDataStore )
+router.put('/updateDataStore', geoserverController.updateDataStore);
+router.get('/updateAllDataStores', geoserverController.updateAllDataStores);
+
 
 module.exports = router

--- a/services/geoServer.service.js
+++ b/services/geoServer.service.js
@@ -162,11 +162,56 @@ module.exports = geoServerService = {
       }
     }
   },
+  
+  async getDataStoreData(nameWorkspace, nameDataStore) {
+    const urlDS = `${confGeoServer.host}workspaces/${nameWorkspace}/datastores/${nameDataStore}.json`;
+    const result = axios.get(urlDS, CONFIG_JSON).then(resp => resp.data.dataStore).catch(err => err);
+    return result
+  },
 
   async updateDataStore({nameWorkspace, nameDataStore}) {
     const urlD = `${confGeoServer.host}workspaces/${nameWorkspace}/datastores`;
-    const data = geoServerUtil.setDataStore(confDb, nameWorkspace, nameDataStore);
-    console.log(await this.saveGeoServer(data.dataStore.name, 'put', urlD, data, CONFIG_JSON))
+    const isPostGis = await this.getDataStoreData(nameWorkspace, nameDataStore);
+    if (isPostGis && (isPostGis.type === 'PostGIS')) {
+      const data = geoServerUtil.setDataStore(confDb, nameWorkspace, nameDataStore);
+      console.log(await this.saveGeoServer(data.dataStore.name, 'put', urlD, data, CONFIG_JSON))
+    }
+  },
+
+  async getWorkspaces () {
+    const urlWorkspaces = `${confGeoServer.host}workspaces.json`;
+    const result = await axios.get(urlWorkspaces,CONFIG_JSON).then(resp => resp).catch(err => err)
+    return result.status && (result.status === 200) ? result.data.workspaces.workspace : `${result.response.status}/${result.response.statusText} - ${result.response.data}`;
+  },
+
+  async getDataStores(nameWorkspace) {
+    const urlWorkspace = `${confGeoServer.host}workspaces/${nameWorkspace}/datastores.json`;
+    const result = await axios.get(urlWorkspace, CONFIG_JSON).then(resp => resp.data.dataStores.dataStore).catch(err => err);
+    return result;
+  },
+  async updateDataStores(nameWorkspace) {
+    const allDataStores = await this.getDataStores(nameWorkspace);
+    const updatesPromises = [];
+    if (allDataStores) {
+      allDataStores.forEach(({ name }) => {
+        const ds = {nameWorkspace, nameDataStore: name}
+        updatesPromises.push(this.updateDataStore(ds));
+      });
+    }
+    await Promise.all(updatesPromises);
+  },
+
+  async updateAllDataStores () {
+    const result = await this.getWorkspaces();
+    const nameWorkspaces = result.map(({ name }) => name );
+    const updatesPromises = [];
+    if (nameWorkspaces) {
+      nameWorkspaces.forEach(workspace => {
+        updatesPromises.push(this.updateDataStores(workspace));
+      });
+    }
+    await Promise.all(updatesPromises);
+    return result;
   },
 
   async deleteView(views){
@@ -175,7 +220,6 @@ module.exports = geoServerService = {
     for (let view of views) {
 
       view.name = view.name ? view.name : view.title;
-
 
       const urli = `${confGeoServer.host}workspaces/${view.workspace}/featuretypes/${view.name}?recurse=true`;
 


### PR DESCRIPTION
# Endpoints:

Two new endpoins where created:

* geoserver/updateDataStore
this endpoint updates a data store, given a nameWorkspace and nameDataStore, to the same config as in config file.

body: 
```
{
    "nameWorkspace": "Workspace name",
    "nameDataStore": "DataStore name"
}
```

*  geoserver/updateAllDataStore
this endpoint updates all data stores, to the same config as in config file.

# services:

Five new services where created at `geoServer.service.js`:

* getWorkspaces:  
params: none  
This will get all workspaces from geoserver and return them as an object array, with workspace name (string) and workspace href (url)

* getDataStores:  
Return all data stores given a workspace name:  
Params: `nameWorkspace` (string)

* updateDataStore:  
Updates a data store given a workspace name and a data store name:  
params: nameWorkspace (string), nameDataStore (string)

* updateDataStores:  
Update all data stores from a workspace name  
Params: `nameWorkspace` (string)

* updateAllDataStores  
Updates all data stores from all work spaces  
Params: none

# Typos

At validadeDataStore:  
Typo: `nameDatastrore` to `nameDatastore`